### PR TITLE
Fix items with NBT being immediately recollected when extracted

### DIFF
--- a/artist/core/items.lua
+++ b/artist/core/items.lua
@@ -55,7 +55,7 @@ function Items:get_item(hash, obj, slot)
     meta = obj -- Full details
   elseif obj.getItemDetail then
     self.log(("Cache miss for %s - fetching metadata"):format(hash))
-    meta = obj.getItemDetail(slot,true)
+    meta = obj.getItemDetail(slot, true)
   else
     error("Bad argument to get_item")
   end

--- a/artist/core/items.lua
+++ b/artist/core/items.lua
@@ -55,7 +55,7 @@ function Items:get_item(hash, obj, slot)
     meta = obj -- Full details
   elseif obj.getItemDetail then
     self.log(("Cache miss for %s - fetching metadata"):format(hash))
-    meta = obj.getItemDetail(slot)
+    meta = obj.getItemDetail(slot,true)
   else
     error("Bad argument to get_item")
   end

--- a/artist/turtle/init.lua
+++ b/artist/turtle/init.lua
@@ -20,8 +20,8 @@ return function(context)
       -- Scan all slots and attempt to determine which ones should be considered "protected"
       -- Namely, which ones shouldn't we pick up from.
       for i = 1, 16 do
-        local info = turtle.getItemDetail(i,true)
-        if info and info.name == item.meta.name and info.nbt == item.meta.nbt then
+        local info = turtle.getItemDetail(i)
+        if info and info.name == item.meta.name then
           protected_slots[i] = info
         end
       end

--- a/artist/turtle/init.lua
+++ b/artist/turtle/init.lua
@@ -20,8 +20,8 @@ return function(context)
       -- Scan all slots and attempt to determine which ones should be considered "protected"
       -- Namely, which ones shouldn't we pick up from.
       for i = 1, 16 do
-        local info = turtle.getItemDetail(i)
-        if info and info.name == item.meta.name and info.damage == item.meta.damage then
+        local info = turtle.getItemDetail(i,true)
+        if info and info.name == item.meta.name and info.nbt == item.meta.nbt then
           protected_slots[i] = info
         end
       end


### PR DESCRIPTION
This change makes the system use NBT to decide whether or not to recollect the items inside of the turtle inventory, which makes items such as armour, swords, and other NBT-bearing items work fine.